### PR TITLE
[Fixes #14] Adds 301 redirects for many old urls

### DIFF
--- a/Web.config
+++ b/Web.config
@@ -34,6 +34,35 @@
             </assemblies>
         </compilation>
     </system.web>
+	<system.webServer>
+		<rewrite>
+			<rules>
+				<rule name="Redirect old module and theme urls including naked root">
+					<match url="^List/((?:Modules|Themes)[/]?.*)" />
+					<action type="Redirect" url="Packages/{R:1}" />
+				</rule>
+				<rule name="Redirect old tag urls">
+					<match url="^List/Search" />
+					<conditions>
+						<add input="{QUERY_STRING}" pattern="searchTerm=tag%3A%20([^&amp;]+)" />
+					</conditions>
+					<action type="Redirect" url="Tags/{C:1}" appendQueryString="false" />
+				</rule>
+				<rule name="Redirect old download urls">
+					<match url="^Package/Download/(.+)" />
+					<action type="Redirect" url="Download/{R:1}" />
+				</rule>
+				<rule name="Redirect old category urls to modules root (no categories in new site)">
+					<match url="^List/ByCategory/Modules/.+" />
+					<action type="Redirect" url="Packages/Modules" />
+				</rule>
+				<rule name="Redirect old category urls to modules root (no categories in new site) (alternate format)">
+					<match url="^Orchard\.Gallery/Packages/ByCategory" />
+					<action type="Redirect" url="Packages/Modules" appendQueryString="false" />
+				</rule>
+			</rules>
+		</rewrite>
+	</system.webServer>
     <runtime>
         <!-- NOTE: These binding redirects have no runtime effect; they are only here to avoid build warnings. -->
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">


### PR DESCRIPTION
- Missing some of the static support pages as they don't have equivalents on the new site.
- It also shuts down the module categories urls which aren't exposed on the new site at the moment.
